### PR TITLE
Fixes for Safari >= 12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/tooolbox/webdriver
+
+go 1.15


### PR DESCRIPTION
A couple of fixes for Safari version >= 12.0, (since it uses W3C webdriver spec instead of the Selenium one) plus usability/debuggability fixes that were required in fixing this stuff.